### PR TITLE
remove extraneous `roundtrip` parameter from redoc() in dedoc addin, …

### DIFF
--- a/R/addins.R
+++ b/R/addins.R
@@ -29,7 +29,7 @@ roundtrip_active_file <- function() {
   rstudioapi::documentSave(active_file$id)
   docfile <- rmarkdown::render(
     normalizePath(active_file$path),
-    output_format = redoc(roundtrip = TRUE),
+    output_format = redoc(),
     quiet = TRUE,
     clean = TRUE
   )


### PR DESCRIPTION
…fixes #57

My understanding is that this is a remnant of a pre-refactor form of dedoc() as dedoc() currently does not use this parameter and handles the roundtrip process internally; I tested it without the parameter and it seems to work but will require review to make sure I didn't miss anything.